### PR TITLE
[android] implement invalidate() on WebSocketModule to match iOS

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -423,6 +423,7 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
 
   @Override
   public void invalidate() {
+    super.invalidate();
     mOnOpenHandler = null;
     mContentHandlers.clear();
     for (WebSocket socket : mWebSocketConnections.values()) {


### PR DESCRIPTION
When the react native bridge reloads, `invalidate` is called on all the modules. On iOS, this cleanup is already implemented 

https://github.com/facebook/react-native/blob/main/React/CoreModules/RCTWebSocketModule.mm#L54

I'll create a PR upstream as well, not sure why this wasn't already implemented.

For our cases, this is not really required, but it's nice that during development in case the bridge reloads, you'd leave the activity/VC and won't end up in a weird state.