### PR TITLE
Fallback to Shadow Tree measurement if native measure fails

### DIFF
--- a/Libraries/Animated/NativeFabricMeasurerTurboModule.js
+++ b/Libraries/Animated/NativeFabricMeasurerTurboModule.js
@@ -18,10 +18,11 @@ type MeasureInWindowOnSuccessCallback = (
 ) => void;
 
 export interface Spec extends TurboModule {
-  +measureNatively: (viewTag: number, successCallback: MeasureOnSuccessCallback, failCallback: (successCallback: MeasureInWindowOnSuccessCallback) => void) => void,
+  +measureNatively: (viewTag: number, successCallback: MeasureOnSuccessCallback, failCallback: (successCallback: MeasureOnSuccessCallback) => void) => void,
   +measureInWindowNatively: (
     viewTag: number,
-    callback: MeasureInWindowOnSuccessCallback,
+    successCallback: MeasureInWindowOnSuccessCallback,
+    failCallback: (successCallback: MeasureInWindowOnSuccessCallback) => void
   ) => void,
 }
 

--- a/Libraries/Animated/NativeFabricMeasurerTurboModule.js
+++ b/Libraries/Animated/NativeFabricMeasurerTurboModule.js
@@ -18,7 +18,7 @@ type MeasureInWindowOnSuccessCallback = (
 ) => void;
 
 export interface Spec extends TurboModule {
-  +measureNatively: (viewTag: number, callback: MeasureOnSuccessCallback) => void,
+  +measureNatively: (viewTag: number, successCallback: MeasureOnSuccessCallback, failCallback: (successCallback: MeasureInWindowOnSuccessCallback) => void) => void,
   +measureInWindowNatively: (
     viewTag: number,
     callback: MeasureInWindowOnSuccessCallback,

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
@@ -25,7 +25,7 @@ public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleS
   }
 
   @Override
-  public void measureNatively(double viewTag, Callback callback) {
+  public void measureNatively(double viewTag, Callback successCallback, Callback failCallback) {
     getReactApplicationContext().runOnUiQueueThread(() -> {
       try {
         int[] output = measurer.measure((int) viewTag);
@@ -33,10 +33,10 @@ public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleS
         float y = PixelUtil.toDIPFromPixel(output[1]);
         float width = PixelUtil.toDIPFromPixel(output[2]);
         float height = PixelUtil.toDIPFromPixel(output[3]);
-        callback.invoke(0, 0, width, height, x, y);
+        successCallback.invoke(0, 0, width, height, x, y);
       }
       catch(IllegalViewOperationException e) {
-        callback.invoke(0, 0, 0, 0, 0, 0);
+        failCallback.invoke(successCallback);
       }
     });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
@@ -25,7 +25,7 @@ public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleS
   }
 
   @Override
-  public void measureNatively(double viewTag, Callback successCallback, Callback failCallback) {
+  public void measureNatively(double viewTag, Callback onSuccess, Callback onFail) {
     getReactApplicationContext().runOnUiQueueThread(() -> {
       try {
         int[] output = measurer.measure((int) viewTag);
@@ -33,16 +33,17 @@ public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleS
         float y = PixelUtil.toDIPFromPixel(output[1]);
         float width = PixelUtil.toDIPFromPixel(output[2]);
         float height = PixelUtil.toDIPFromPixel(output[3]);
-        successCallback.invoke(0, 0, width, height, x, y);
+        onSuccess.invoke(0, 0, width, height, x, y);
       }
       catch(IllegalViewOperationException e) {
-        failCallback.invoke(successCallback);
+        // To avoid a scoping bug in UIManagerBinding.cpp, we need to pass the successCallback back here. 
+        onFail.invoke(onSuccess);
       }
     });
   }
 
   @Override
-  public void measureInWindowNatively(double viewTag, Callback callback) {
+  public void measureInWindowNatively(double viewTag, Callback onSuccess, Callback onFail) {
     getReactApplicationContext().runOnUiQueueThread(() -> {
       try {
         int[] output = measurer.measureInWindow((int) viewTag);
@@ -50,10 +51,10 @@ public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleS
         float y = PixelUtil.toDIPFromPixel(output[1]);
         float width = PixelUtil.toDIPFromPixel(output[2]);
         float height = PixelUtil.toDIPFromPixel(output[3]);
-        callback.invoke(x, y, width, height);
+        onSuccess.invoke(x, y, width, height);
       }
       catch (IllegalViewOperationException e) {
-        callback.invoke(0,0,0,0);
+        onFail.invoke(onSuccess);
       }
     });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewMeasurer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -26,24 +27,34 @@ public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleS
   @Override
   public void measureNatively(double viewTag, Callback callback) {
     getReactApplicationContext().runOnUiQueueThread(() -> {
-      int[] output = measurer.measure((int) viewTag);
-      float x = PixelUtil.toDIPFromPixel(output[0]);
-      float y = PixelUtil.toDIPFromPixel(output[1]);
-      float width = PixelUtil.toDIPFromPixel(output[2]);
-      float height = PixelUtil.toDIPFromPixel(output[3]);
-      callback.invoke(0, 0, width, height, x, y);
+      try {
+        int[] output = measurer.measure((int) viewTag);
+        float x = PixelUtil.toDIPFromPixel(output[0]);
+        float y = PixelUtil.toDIPFromPixel(output[1]);
+        float width = PixelUtil.toDIPFromPixel(output[2]);
+        float height = PixelUtil.toDIPFromPixel(output[3]);
+        callback.invoke(0, 0, width, height, x, y);
+      }
+      catch(IllegalViewOperationException e) {
+        callback.invoke(0, 0, 0, 0, 0, 0);
+      }
     });
   }
 
   @Override
   public void measureInWindowNatively(double viewTag, Callback callback) {
     getReactApplicationContext().runOnUiQueueThread(() -> {
-      int[] output = measurer.measureInWindow((int) viewTag);
-      float x = PixelUtil.toDIPFromPixel(output[0]);
-      float y = PixelUtil.toDIPFromPixel(output[1]);
-      float width = PixelUtil.toDIPFromPixel(output[2]);
-      float height = PixelUtil.toDIPFromPixel(output[3]);
-      callback.invoke(x, y, width, height);
+      try {
+        int[] output = measurer.measureInWindow((int) viewTag);
+        float x = PixelUtil.toDIPFromPixel(output[0]);
+        float y = PixelUtil.toDIPFromPixel(output[1]);
+        float width = PixelUtil.toDIPFromPixel(output[2]);
+        float height = PixelUtil.toDIPFromPixel(output[3]);
+        callback.invoke(x, y, width, height);
+      }
+      catch (IllegalViewOperationException e) {
+        callback.invoke(0,0,0,0);
+      }
     });
   }
 

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -16,10 +16,8 @@
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #include <react/renderer/uimanager/primitives.h>
 
-#include <algorithm>
 #include <utility>
 
-#include <logger/react_native_log.h>
 #include "bindingUtils.h"
 
 namespace facebook::react {

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -103,23 +103,22 @@ void UIManagerBinding::dispatchEvent(
     return;
   }
 
-  auto instanceHandle = eventTarget != nullptr ? [&]() {
-    auto instanceHandle = eventTarget->getInstanceHandle(runtime);
-    if (instanceHandle.isUndefined()) {
-      return jsi::Value::null();
-    }
+  auto instanceHandle = eventTarget != nullptr
+    ? [&]() {
+      auto instanceHandle = eventTarget->getInstanceHandle(runtime);
+      if (instanceHandle.isUndefined()) {
+        return jsi::Value::null();
+      }
 
-    // Mixing `target` into `payload`.
-    if (!payload.isObject()) {
-      LOG(ERROR) << "payload for dispatchEvent is not an object: "
-                 << eventTarget->getTag();
-    }
-    react_native_assert(payload.isObject());
-    payload.asObject(runtime).setProperty(
-        runtime, "target", eventTarget->getTag());
-    return instanceHandle;
-  }()
-                                               : jsi::Value::null();
+      // Mixing `target` into `payload`.
+      if (!payload.isObject()) {
+        LOG(ERROR) << "payload for dispatchEvent is not an object: " << eventTarget->getTag();
+      }
+      react_native_assert(payload.isObject());
+      payload.asObject(runtime).setProperty(runtime, "target", eventTarget->getTag());
+      return instanceHandle;
+    }()
+    : jsi::Value::null();
 
   if (instanceHandle.isNull()) {
     LOG(WARNING) << "instanceHandle is null, event will be dropped";

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -618,7 +618,7 @@ jsi::Value UIManagerBinding::get(
                         if (std::all_of(arr, arr+6, [](int x) {return x==0;})) {
                           measureFromShadowTree(uiManager,shadowNode, onSuccessFunction, runtime);
                         }
-                        onSuccessFunction.call(runtime, arr);
+                        onSuccessFunction.call(runtime, *arr);
                       });
               turboModuleCalled = true;
           }

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -633,7 +633,6 @@ jsi::Value UIManagerBinding::get(
             jsi::Value const *arguments,
             size_t /*count*/) noexcept -> jsi::Value {
           auto shadowNode = shadowNodeFromValue(runtime, arguments[0]);
-          bool turboModuleCalled = false;
           auto nativeMeasurerValue =
               runtime.global()
                   .getProperty(runtime, "__turboModuleProxy")
@@ -677,10 +676,6 @@ jsi::Value UIManagerBinding::get(
                                   uiManager, shadowNode, onSuccessFunction, rt);
                               return jsi::Value::undefined();
                             }));
-            turboModuleCalled = true;
-          }
-
-          if (turboModuleCalled) {
             return jsi::Value::undefined();
           }
 
@@ -702,7 +697,6 @@ jsi::Value UIManagerBinding::get(
             jsi::Value const *arguments,
             size_t /*count*/) noexcept -> jsi::Value {
           auto shadowNode = shadowNodeFromValue(runtime, arguments[0]);
-          bool turboModuleCalled = false;
           auto nativeMeasurerValue =
               runtime.global()
                   .getProperty(runtime, "__turboModuleProxy")
@@ -742,10 +736,6 @@ jsi::Value UIManagerBinding::get(
                                   uiManager, shadowNode, onSuccessFunction, rt);
                               return jsi::Value::undefined();
                             }));
-            turboModuleCalled = true;
-          }
-
-          if (turboModuleCalled) {
             return jsi::Value::undefined();
           }
 

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -160,6 +160,7 @@ void measureFromShadowTree(UIManager* uiManager, ShadowNode::Shared shadowNode, 
                                    : Point();
 
     auto frame = layoutMetrics.frame;
+    react_native_log_info("garf measureFromShadowTree about to onSuccessFunction");
     onSuccessFunction.call(
             runtime,
             {jsi::Value{runtime, (double)originRelativeToParent.x},
@@ -620,27 +621,18 @@ jsi::Value UIManagerBinding::get(
               .call(
                 runtime, 
                 shadowNode.get()->getTag(), 
+                onSuccessFunction,
                 jsi::Function::createFromHostFunction(
                   runtime, 
                   jsi::PropNameID::forAscii(runtime, "pleaseRenameThisFunction"), 
-                  6,
-                  [uiManager, shadowNode, &onSuccessFunction](
+                  1,
+                  [uiManager, shadowNode](
                       jsi::Runtime& rt, 
                       const jsi::Value& thisVal, 
                       const jsi::Value* args, 
                       size_t count) {
-                    auto isAllZeros = true;
-                    for (int i = 0; i < 6; ++i) {
-                        if (args[i].asNumber() != 0) {
-                            isAllZeros = false;
-                            break;
-                        }
-                    }
-                    if (isAllZeros) {
-                        measureFromShadowTree(uiManager,shadowNode, onSuccessFunction, rt);
-                        return jsi::Value::undefined();
-                    }
-                    onSuccessFunction.call(rt, args, (size_t)6);
+                    auto onSuccessFunction = args[0].getObject(rt).getFunction(rt);
+                    measureFromShadowTree(uiManager,shadowNode, onSuccessFunction, rt);
                     return jsi::Value::undefined();
                   }
                 )

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -667,9 +667,16 @@ jsi::Value UIManagerBinding::get(
                                 const jsi::Value &thisVal,
                                 const jsi::Value *args,
                                 size_t count) {
-                              // We return onSuccessFunction out of the onFail
-                              // instead of using the one defined above to avoid
-                              // a scoping bug.
+                              // There's a bug that occurs if, below, we try to
+                              // call the onSuccessFunction we extracted
+                              // earlier. It seems that JSIFunctions can't be
+                              // passed into capture clauses for c++ anonymous
+                              // functions, because they lack the appropriate
+                              // copy constructor. Since we do definitely need
+                              // access to the onSuccessFunction, we obtain that
+                              // access by passing it into the .call() above and
+                              // then passing it BACK OUT in native land, so we
+                              // can extract it from args and use it right here.
                               auto onSuccessFunction =
                                   args[0].getObject(rt).getFunction(rt);
                               measureFromShadowTree(
@@ -727,9 +734,16 @@ jsi::Value UIManagerBinding::get(
                                 const jsi::Value &thisVal,
                                 const jsi::Value *args,
                                 size_t count) {
-                              // We return onSuccessFunction out of the onFail
-                              // instead of using the one defined above to avoid
-                              // a scoping bug.
+                              // There's a bug that occurs if, below, we try to
+                              // call the onSuccessFunction we extracted
+                              // earlier. It seems that JSIFunctions can't be
+                              // passed into capture clauses for c++ anonymous
+                              // functions, because they lack the appropriate
+                              // copy constructor. Since we do definitely need
+                              // access to the onSuccessFunction, we obtain that
+                              // access by passing it into the .call() above and
+                              // then passing it BACK OUT in native land, so we
+                              // can extract it from args and use it right here.
                               auto onSuccessFunction =
                                   args[0].getObject(rt).getFunction(rt);
                               measureInWindowFromShadowTree(


### PR DESCRIPTION
When tapping a hyperlink that exists as a child of another `<Text>` element, the app crashes. This happens because the NativeFabricMeasurerTurboModule is called for the hyperlink's node tag _as it exists in the c++ shadow tree_, and that tag is (for reasons we don't understand) different from the actual tag that exists in the native layout. Thus, the TurboModule ends up looking for info on a node tag that doesn't exist, which crashes the native app. To resolve this, this PR gracefully handles that error, and in such a case we fallback to determining layout information from the shadow tree, as we were doing before Alex's TurboModule. 