### PR TITLE
Toggle the new Android prop diffing mechanism for components

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5de2cfc00f486b7d07266939ce18a397>>
+ * @generated SignedSource<<2b92c4d0536f4ce46db9c7a17d7e7469>>
  */
 
 /**
@@ -65,7 +65,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enablePreciseSchedulingForPremountItemsOnAndroid(): Boolean = false
 
-  override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
+  override fun enablePropsUpdateReconciliationAndroid(): Boolean = true
 
   override fun enableReportEventPaintTime(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e38a0e9474ac349a4b8153862470c856>>
+ * @generated SignedSource<<054aa32e23061957eb17d1c98b3d4534>>
  */
 
 /**
@@ -112,7 +112,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enablePropsUpdateReconciliationAndroid() override {
-    return false;
+    return true;
   }
 
   bool enableReportEventPaintTime() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -247,7 +247,7 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     enablePropsUpdateReconciliationAndroid: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2024-07-12',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3037cf1c938dae492b656333cec9633c>>
+ * @generated SignedSource<<c77be228c968428738d0c8fea2a46af0>>
  * @flow strict
  */
 
@@ -274,7 +274,7 @@ export const enablePreciseSchedulingForPremountItemsOnAndroid: Getter<boolean> =
 /**
  * When enabled, Android will receive prop updates based on the differences between the last rendered shadow node and the last committed shadow node.
  */
-export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNativeFlagGetter('enablePropsUpdateReconciliationAndroid', false);
+export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNativeFlagGetter('enablePropsUpdateReconciliationAndroid', true);
 /**
  * Report paint time inside the Event Timing API implementation (PerformanceObserver).
  */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Requires updating the fork to react-native 0.79** or cherrypicking the following commits from [David Vacca](https://github.com/mdvacca?tab=overview&from=2024-11-01&to=2024-11-30): 
- Implement prop diffing for accessibility props in View [#48833](https://github.com/facebook/react-native/pull/48833)
- Implement prop diffing for transform props in View [#48832](https://github.com/facebook/react-native/pull/48832)
- Implement prop diffing for border props in View [#48831](https://github.com/facebook/react-native/pull/48831)
- Implement prop diffing for event props in View [#48830](https://github.com/facebook/react-native/pull/48830)
- Implement prop diffing for basic props in View [#48829](https://github.com/facebook/react-native/pull/48829)

Enables feature flag enablePropsUpdateReconciliationAndroid to fix https://app.asana.com/1/236888843494340/project/1199705967702853/task/1209601835367711?focus=true

More info at https://github.com/facebook/react-native/pull/45551 and https://github.com/discord/react-native/blob/e0702345591cb461e196aabd8be0bf51839a2df3/packages/react-native/scripts/featureflags/README.md

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

This diffs toggles the new Android prop diffing mechanism for components

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Branch 0.78:

| Before enabling the feature flag    | After enabling the feature flag |
| ----------- | ----------- |
| <img src="https://github.com/user-attachments/assets/10a03e97-1e6d-47fd-8492-c02ca3fd0044" width="350" />      | <img src="https://github.com/user-attachments/assets/3bc480b3-3f0b-45a3-aec0-9af1220d0fa5" width="350" />       |

Branch 0.80.0, 0.79, 0.78.2 upstream:

<img width="1558" alt="Screenshot 2025-05-08 at 4 04 47 PM" src="https://github.com/user-attachments/assets/bef7fe49-f736-4f51-be6c-98399605abb0" />


Branch 0.78.0, 0.78.1 upstream:

<img width="1000" alt="Screenshot 2025-05-07 at 8 08 44 PM" src="https://github.com/user-attachments/assets/64dcdabb-e906-4d59-89ed-0127cdee5fdb" />

<image src="https://github.com/user-attachments/assets/36557f2f-de2f-4304-b19a-ca9693901006" width="250" />

Discord app - new arch branch - Unresponsive screen, views have a gray background color.

<image src="https://github.com/user-attachments/assets/e2a5b5f0-d14a-4d1c-bb4c-f07834cb597f" width="350" />



