### PR TITLE
Toggle the new Android prop diffing mechanism for components (0.78.2)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11d93a900862ed8ce98f90f9af2de47b>>
+ * @generated SignedSource<<16a044e68001307dc901537101b73db9>>
  */
 
 /**
@@ -65,7 +65,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enablePreciseSchedulingForPremountItemsOnAndroid(): Boolean = false
 
-  override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
+  override fun enablePropsUpdateReconciliationAndroid(): Boolean = true
 
   override fun enableReportEventPaintTime(): Boolean = false
 
@@ -109,7 +109,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun useRuntimeShadowNodeReferenceUpdate(): Boolean = true
 
-  override fun useShadowNodeStateOnClone(): Boolean = true
+  override fun useShadowNodeStateOnClone(): Boolean = false
 
   override fun useTurboModuleInterop(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<830cdd4b394262ee65abc63a54833674>>
+ * @generated SignedSource<<7ee9e37d5f14514dfccd01a6fdda920b>>
  */
 
 /**
@@ -112,7 +112,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enablePropsUpdateReconciliationAndroid() override {
-    return false;
+    return true;
   }
 
   bool enableReportEventPaintTime() override {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -135,6 +135,349 @@ SharedDebugStringConvertibleList HostPlatformViewProps::getDebugProps() const {
 
 #ifdef ANDROID
 
+inline static void updateEventProp(
+    folly::dynamic& result,
+    const ViewEvents& newEvents,
+    const ViewEvents& oldEvents,
+    const ViewEvents::Offset& offset,
+    const std::string& name) {
+  if (newEvents[offset] != oldEvents[offset]) {
+    auto value = newEvents[offset];
+    result[name] = value;
+  }
+}
+
+static void updateBorderWidthPropValue(
+    folly::dynamic& result,
+    const std::string& propName,
+    const std::optional<float>& newValue,
+    const std::optional<float>& oldValue) {
+  if (newValue != oldValue) {
+    if (newValue.has_value()) {
+      result[propName] = newValue.value();
+    } else {
+      result[propName] = NULL;
+    }
+  }
+}
+
+static void updateBorderWidthProps(
+    folly::dynamic& result,
+    const CascadedBorderWidths& newBorderWidths,
+    const CascadedBorderWidths& oldBorderWidths) {
+  updateBorderWidthPropValue(
+      result, "borderWidth", newBorderWidths.all, oldBorderWidths.all);
+  updateBorderWidthPropValue(
+      result, "borderTopWidth", newBorderWidths.top, oldBorderWidths.top);
+  updateBorderWidthPropValue(
+      result, "borderLeftWidth", newBorderWidths.left, oldBorderWidths.left);
+  updateBorderWidthPropValue(
+      result, "borderStartWidth", newBorderWidths.start, oldBorderWidths.start);
+  updateBorderWidthPropValue(
+      result, "borderEndWidth", newBorderWidths.end, oldBorderWidths.end);
+  updateBorderWidthPropValue(
+      result, "borderRightWidth", newBorderWidths.right, oldBorderWidths.right);
+  updateBorderWidthPropValue(
+      result,
+      "borderBottomWidth",
+      newBorderWidths.bottom,
+      oldBorderWidths.bottom);
+}
+
+static void updateBorderRadiusPropValue(
+    folly::dynamic& result,
+    const std::string& propName,
+    const std::optional<ValueUnit>& newValue,
+    const std::optional<ValueUnit>& oldValue) {
+  if (newValue != oldValue) {
+    if (newValue.has_value()) {
+      if (newValue.value().unit == UnitType::Percent) {
+        result[propName] = std::to_string(newValue.value().value) + "%";
+      } else {
+        result[propName] = newValue.value().value;
+      }
+    } else {
+      result[propName] = -1;
+    }
+  }
+}
+
+static void updateBorderRadiusProps(
+    folly::dynamic& result,
+    const CascadedBorderRadii& newBorderRadii,
+    const CascadedBorderRadii& oldBorderRadii) {
+  updateBorderRadiusPropValue(
+      result, "borderRadius", newBorderRadii.all, oldBorderRadii.all);
+  updateBorderRadiusPropValue(
+      result,
+      "borderTopLeftRadius",
+      newBorderRadii.topLeft,
+      oldBorderRadii.topLeft);
+  updateBorderRadiusPropValue(
+      result,
+      "borderTopRightRadius",
+      newBorderRadii.topRight,
+      oldBorderRadii.topRight);
+  updateBorderRadiusPropValue(
+      result,
+      "borderBottomRightRadius",
+      newBorderRadii.bottomRight,
+      oldBorderRadii.bottomRight);
+  updateBorderRadiusPropValue(
+      result,
+      "borderBottomLeftRadius",
+      newBorderRadii.bottomLeft,
+      oldBorderRadii.bottomLeft);
+  updateBorderRadiusPropValue(
+      result,
+      "borderTopStartRadius",
+      newBorderRadii.topStart,
+      oldBorderRadii.topStart);
+  updateBorderRadiusPropValue(
+      result,
+      "borderTopEndRadius",
+      newBorderRadii.topEnd,
+      oldBorderRadii.topEnd);
+  updateBorderRadiusPropValue(
+      result,
+      "borderBottomStartRadius",
+      newBorderRadii.bottomStart,
+      oldBorderRadii.bottomStart);
+  updateBorderRadiusPropValue(
+      result,
+      "borderBottomEndRadius",
+      newBorderRadii.bottomEnd,
+      oldBorderRadii.bottomEnd);
+  updateBorderRadiusPropValue(
+      result,
+      "borderEndEndRadius",
+      newBorderRadii.endEnd,
+      oldBorderRadii.endEnd);
+  updateBorderRadiusPropValue(
+      result,
+      "borderEndStartRadius",
+      newBorderRadii.endStart,
+      oldBorderRadii.endStart);
+  updateBorderRadiusPropValue(
+      result,
+      "borderStartEndRadius",
+      newBorderRadii.startEnd,
+      oldBorderRadii.startEnd);
+  updateBorderRadiusPropValue(
+      result,
+      "borderStartStartRadius",
+      newBorderRadii.startStart,
+      oldBorderRadii.startStart);
+}
+
+static void updateBorderStyleProps(
+    folly::dynamic& result,
+    const CascadedBorderStyles& newBorderStyle,
+    const CascadedBorderStyles& oldBorderStyle) {
+  if (newBorderStyle.all != oldBorderStyle.all) {
+    if (newBorderStyle.all.has_value()) {
+      switch (newBorderStyle.all.value()) {
+        case BorderStyle::Solid:
+          result["borderStyle"] = "solid";
+          break;
+        case BorderStyle::Dotted:
+          result["borderStyle"] = "dotted";
+          break;
+        case BorderStyle::Dashed:
+          result["borderStyle"] = "dashed";
+          break;
+      }
+    } else {
+      result["borderStyle"] = NULL;
+    }
+  }
+}
+
+static void updateBorderColorPropValue(
+    folly::dynamic& result,
+    const std::string& propName,
+    const std::optional<SharedColor>& newColor,
+    const std::optional<SharedColor>& oldColor) {
+  if (newColor != oldColor) {
+    result[propName] = newColor.has_value() ? *newColor.value() : NULL;
+  }
+}
+
+static void updateBorderColorsProps(
+    folly::dynamic& result,
+    const CascadedBorderColors& newBorderColor,
+    const CascadedBorderColors& oldBorderColor) {
+  updateBorderColorPropValue(
+      result, "borderColor", newBorderColor.all, oldBorderColor.all);
+  updateBorderColorPropValue(
+      result, "borderLeftColor", newBorderColor.left, oldBorderColor.left);
+  updateBorderColorPropValue(
+      result, "borderRightColor", newBorderColor.right, oldBorderColor.right);
+  updateBorderColorPropValue(
+      result, "borderTopColor", newBorderColor.top, oldBorderColor.top);
+  updateBorderColorPropValue(
+      result,
+      "borderBottomColor",
+      newBorderColor.bottom,
+      oldBorderColor.bottom);
+  updateBorderColorPropValue(
+      result, "borderStartColor", newBorderColor.start, oldBorderColor.start);
+  updateBorderColorPropValue(
+      result, "borderBlockColor", newBorderColor.block, oldBorderColor.block);
+  updateBorderColorPropValue(
+      result,
+      "borderBlockEndColor",
+      newBorderColor.blockEnd,
+      oldBorderColor.blockEnd);
+  updateBorderColorPropValue(
+      result,
+      "borderBlockStartColor",
+      newBorderColor.blockStart,
+      oldBorderColor.blockStart);
+}
+
+inline static void updateNativeDrawableProp(
+    folly::dynamic& result,
+    const std::string& propName,
+    const std::optional<NativeDrawable>& nativeDrawable) {
+  folly::dynamic nativeDrawableResult;
+  if (nativeDrawable.has_value()) {
+    nativeDrawableResult = folly::dynamic::object();
+    const auto& nativeDrawableValue = nativeDrawable.value();
+    nativeDrawableResult["attribute"] = nativeDrawableValue.themeAttr;
+    switch (nativeDrawableValue.kind) {
+      case NativeDrawable::Kind::Ripple:
+        nativeDrawableResult["type"] = "RippleAndroid";
+        break;
+      case NativeDrawable::Kind::ThemeAttr:
+        nativeDrawableResult["type"] = "ThemeAttrAndroid";
+        break;
+    }
+    if (nativeDrawableValue.ripple.rippleRadius.has_value()) {
+      nativeDrawableResult["rippleRadius"] =
+          nativeDrawableValue.ripple.rippleRadius.value();
+    }
+    if (nativeDrawableValue.ripple.color.has_value()) {
+      nativeDrawableResult["color"] = nativeDrawableValue.ripple.color.value();
+    }
+    nativeDrawableResult["borderless"] = nativeDrawableValue.ripple.borderless;
+  } else {
+    nativeDrawableResult = folly::dynamic(nullptr);
+  }
+
+  result[propName] = nativeDrawableResult;
+}
+
+inline static void updateTransformOperationValue(
+    const std::string& operationName,
+    const ValueUnit& valueUnit,
+    folly::dynamic& resultTranslateArray) {
+  folly::dynamic resultTranslate = folly::dynamic::object();
+  if (valueUnit.unit == UnitType::Percent) {
+    resultTranslate[operationName] = std::to_string(valueUnit.value) + "%";
+  } else {
+    resultTranslate[operationName] = valueUnit.value;
+  }
+  resultTranslateArray.push_back(std::move(resultTranslate));
+}
+
+inline static void updateTransformProps(
+    const Transform& transform,
+    const TransformOperation& operation,
+    folly::dynamic& resultTranslateArray) {
+  // See serialization rules in:
+  // react-native-github/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h?lines=592
+  std::string operationName;
+  switch (operation.type) {
+    case TransformOperationType::Scale:
+      operationName = "scale";
+      if (operation.x == operation.y && operation.x == operation.z) {
+        updateTransformOperationValue(
+            operationName, operation.x, resultTranslateArray);
+        return;
+      }
+      break;
+    case TransformOperationType::Translate:
+      operationName = "translate";
+      break;
+    case TransformOperationType::Rotate:
+      operationName = "rotate";
+      break;
+    case TransformOperationType::Perspective:
+      operationName = "perspective";
+      break;
+    case TransformOperationType::Arbitrary:
+      operationName = "matrix";
+      resultTranslateArray[operationName] = transform;
+      break;
+    case TransformOperationType::Identity:
+      // Do nothing
+      break;
+    case TransformOperationType::Skew:
+      operationName = "skew";
+      break;
+  }
+  if (operation.x.value != 0) {
+    updateTransformOperationValue(
+        operationName + "X", operation.x, resultTranslateArray);
+  }
+  if (operation.y.value != 0) {
+    updateTransformOperationValue(
+        operationName + "Y", operation.y, resultTranslateArray);
+  }
+  if (operation.z.value != 0) {
+    updateTransformOperationValue(
+        operationName + "Z", operation.z, resultTranslateArray);
+  }
+}
+
+inline static void updateAccessibilityStateProp(
+    folly::dynamic& result,
+    const std::optional<AccessibilityState>& newState,
+    const std::optional<AccessibilityState>& oldState) {
+  folly::dynamic resultState = folly::dynamic::object();
+
+  if (!newState.has_value() && oldState.has_value()) {
+    result["accessibilityState"] = resultState;
+    return;
+  }
+
+  if (!oldState.has_value() || newState->disabled != oldState->disabled) {
+    resultState["disabled"] = newState->disabled;
+  }
+
+  if (!oldState.has_value() || newState->selected != oldState->selected) {
+    resultState["selected"] = newState->selected;
+  }
+
+  if (!oldState.has_value() || newState->busy != oldState->busy) {
+    resultState["busy"] = newState->busy;
+  }
+
+  if (!oldState.has_value() || newState->expanded != oldState->expanded) {
+    resultState["expanded"] =
+        newState->expanded.has_value() && newState->expanded.value();
+  }
+
+  if (!oldState.has_value() || newState->checked != oldState->checked) {
+    switch (newState->checked) {
+      case AccessibilityState::Unchecked:
+        resultState["checked"] = "unchecked";
+        break;
+      case AccessibilityState::Checked:
+        resultState["checked"] = "checked";
+        break;
+      case AccessibilityState::Mixed:
+        resultState["checked"] = "mixed";
+        break;
+      case AccessibilityState::None:
+        resultState["checked"] = "none";
+        break;
+    }
+  }
+  result["accessibilityState"] = resultState;
+}
+
 folly::dynamic HostPlatformViewProps::getDiffProps(
     const Props* prevProps) const {
   folly::dynamic result = folly::dynamic::object();
@@ -145,8 +488,442 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
       ? &defaultProps
       : static_cast<const HostPlatformViewProps*>(prevProps);
 
+  if (this == oldProps) {
+    return result;
+  }
+
+  if (elevation != oldProps->elevation) {
+    result["elevation"] = elevation;
+  }
+
   if (focusable != oldProps->focusable) {
     result["focusable"] = focusable;
+  }
+
+  if (hasTVPreferredFocus != oldProps->hasTVPreferredFocus) {
+    result["hasTVPreferredFocus"] = hasTVPreferredFocus;
+  }
+
+  if (needsOffscreenAlphaCompositing !=
+      oldProps->needsOffscreenAlphaCompositing) {
+    result["needsOffscreenAlphaCompositing"] = needsOffscreenAlphaCompositing;
+  }
+
+  if (renderToHardwareTextureAndroid !=
+      oldProps->renderToHardwareTextureAndroid) {
+    result["renderToHardwareTextureAndroid"] = renderToHardwareTextureAndroid;
+  }
+
+  if (opacity != oldProps->opacity) {
+    result["opacity"] = opacity;
+  }
+
+  if (backgroundColor != oldProps->backgroundColor) {
+    result["backgroundColor"] = *backgroundColor;
+  }
+
+  if (shadowColor != oldProps->shadowColor) {
+    result["shadowColor"] = *shadowColor;
+  }
+
+  if (shadowOpacity != oldProps->shadowOpacity) {
+    result["shadowOpacity"] = shadowOpacity;
+  }
+
+  if (shadowRadius != oldProps->shadowRadius) {
+    result["shadowRadius"] = shadowRadius;
+  }
+
+  if (shouldRasterize != oldProps->shouldRasterize) {
+    result["shouldRasterize"] = shouldRasterize;
+  }
+
+  if (collapsable != oldProps->collapsable) {
+    result["collapsable"] = collapsable;
+  }
+
+  if (removeClippedSubviews != oldProps->removeClippedSubviews) {
+    result["removeClippedSubviews"] = removeClippedSubviews;
+  }
+
+  if (onLayout != oldProps->onLayout) {
+    result["onLayout"] = onLayout;
+  }
+
+  if (zIndex != oldProps->zIndex) {
+    result["zIndex"] = zIndex.value();
+  }
+
+  if (pointerEvents != oldProps->pointerEvents) {
+    std::string value;
+    switch (pointerEvents) {
+      case PointerEventsMode::BoxOnly:
+        result["pointerEvents"] = "box-only";
+        break;
+      case PointerEventsMode::BoxNone:
+        result["pointerEvents"] = "box-none";
+        break;
+      case PointerEventsMode::None:
+        result["pointerEvents"] = "none";
+        break;
+      default:
+        result["pointerEvents"] = "auto";
+        break;
+    }
+  }
+
+  if (nativeId != oldProps->nativeId) {
+    result["nativeId"] = nativeId;
+  }
+
+  if (testId != oldProps->testId) {
+    result["testId"] = testId;
+  }
+
+  if (accessible != oldProps->accessible) {
+    result["accessible"] = accessible;
+  }
+
+  if (getClipsContentToBounds() != oldProps->getClipsContentToBounds()) {
+    result["overflow"] = getClipsContentToBounds() ? "hidden" : "visible";
+    result["scroll"] = result["overflow"];
+  }
+
+  if (backfaceVisibility != oldProps->backfaceVisibility) {
+    switch (backfaceVisibility) {
+      case BackfaceVisibility::Auto:
+        result["backfaceVisibility"] = "auto";
+        break;
+      case BackfaceVisibility::Visible:
+        result["backfaceVisibility"] = "visible";
+        break;
+      case BackfaceVisibility::Hidden:
+        result["backfaceVisibility"] = "hidden";
+        break;
+    }
+  }
+
+  if (nativeBackground != oldProps->nativeBackground) {
+    updateNativeDrawableProp(
+        result, "nativeBackgroundAndroid", nativeBackground);
+  }
+
+  if (nativeForeground != oldProps->nativeForeground) {
+    updateNativeDrawableProp(
+        result, "nativeForegroundAndroid", nativeForeground);
+  }
+
+  // Events
+  // TODO T212662692: pass events as std::bitset<64> to java
+  if (events != oldProps->events) {
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerEnter,
+        "onPointerEnter");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerEnterCapture,
+        "onPointerEnterCapture");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerMove,
+        "onPointerMove");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerMoveCapture,
+        "onPointerMoveCapture");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerLeave,
+        "onPointerLeave");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerLeaveCapture,
+        "onPointerLeaveCapture");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerOver,
+        "onPointerOver");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerOut,
+        "onPointerOut");
+    updateEventProp(
+        result, events, oldProps->events, ViewEvents::Offset::Click, "onClick");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::MoveShouldSetResponder,
+        "onMoveShouldSetResponder");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::MoveShouldSetResponderCapture,
+        "onMoveShouldSetResponderCapture");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::StartShouldSetResponder,
+        "onStartShouldSetResponder");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::StartShouldSetResponderCapture,
+        "onStartShouldSetResponderCapture");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderGrant,
+        "onResponderGrant");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderReject,
+        "onResponderReject");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderStart,
+        "onResponderStart");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderEnd,
+        "onResponderEnd");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderRelease,
+        "onResponderRelease");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderMove,
+        "onResponderMove");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderTerminate,
+        "onResponderTerminate");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ResponderTerminationRequest,
+        "onResponderTerminationRequest");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ShouldBlockNativeResponder,
+        "onShouldBlockNativeResponder");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::TouchStart,
+        "onTouchStart");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::TouchMove,
+        "onTouchMove");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::TouchEnd,
+        "onTouchEnd");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::TouchCancel,
+        "onTouchCancel");
+  }
+
+  // Borders
+  auto borderWidths = getBorderWidths();
+  auto oldBorderWidths = oldProps->getBorderWidths();
+  if (borderWidths != oldBorderWidths) {
+    updateBorderWidthProps(result, borderWidths, oldBorderWidths);
+  }
+
+  if (borderStyles != oldProps->borderStyles) {
+    updateBorderStyleProps(result, borderStyles, oldProps->borderStyles);
+  }
+
+  if (borderColors != oldProps->borderColors) {
+    updateBorderColorsProps(result, borderColors, oldProps->borderColors);
+  }
+
+  if (borderRadii != oldProps->borderRadii) {
+    updateBorderRadiusProps(result, borderRadii, oldProps->borderRadii);
+  }
+
+  // Transforms
+  if (transform != oldProps->transform ||
+      transformOrigin != oldProps->transformOrigin) {
+    folly::dynamic resultTranslateArray = folly::dynamic::array();
+    for (const auto& operation : transform.operations) {
+      updateTransformProps(transform, operation, resultTranslateArray);
+    }
+    result["transform"] = std::move(resultTranslateArray);
+  }
+
+  if (transformOrigin != oldProps->transformOrigin) {
+    result["transformOrigin"] = transformOrigin;
+  }
+
+  // Accessibility
+
+  if (accessibilityState != oldProps->accessibilityState) {
+    updateAccessibilityStateProp(
+        result, oldProps->accessibilityState, accessibilityState);
+  }
+
+  if (accessibilityLabel != oldProps->accessibilityLabel) {
+    result["accessibilityLabel"] = accessibilityLabel;
+  }
+
+  if (accessibilityLabelledBy != oldProps->accessibilityLabelledBy) {
+    auto accessibilityLabelledByValues = folly::dynamic::array();
+    for (const auto& accessibilityLabelledByValue :
+         accessibilityLabelledBy.value) {
+      accessibilityLabelledByValues.push_back(accessibilityLabelledByValue);
+    }
+    result["accessibilityLabelledBy"] = accessibilityLabelledByValues;
+  }
+
+  if (accessibilityLiveRegion != oldProps->accessibilityLiveRegion) {
+    switch (accessibilityLiveRegion) {
+      case AccessibilityLiveRegion::Assertive:
+        result["accessibilityLiveRegion"] = "assertive";
+        break;
+      case AccessibilityLiveRegion::Polite:
+        result["accessibilityLiveRegion"] = "polite";
+        break;
+      case AccessibilityLiveRegion::None:
+        result["accessibilityLiveRegion"] = "none";
+        break;
+    }
+  }
+
+  if (accessibilityHint != oldProps->accessibilityHint) {
+    result["accessibilityHint"] = accessibilityHint;
+  }
+
+  if (accessibilityRole != oldProps->accessibilityRole) {
+    result["accessibilityRole"] = accessibilityRole;
+  }
+
+  if (accessibilityLanguage != oldProps->accessibilityLanguage) {
+    result["accessibilityLanguage"] = accessibilityLanguage;
+  }
+
+  if (accessibilityValue != oldProps->accessibilityValue) {
+    folly::dynamic accessibilityValueObject = folly::dynamic::object();
+    if (accessibilityValue.min.has_value()) {
+      accessibilityValueObject["min"] = accessibilityValue.min.value();
+    }
+    if (accessibilityValue.max.has_value()) {
+      accessibilityValueObject["max"] = accessibilityValue.max.value();
+    }
+    if (accessibilityValue.now.has_value()) {
+      accessibilityValueObject["now"] = accessibilityValue.now.value();
+    }
+    if (accessibilityValue.text.has_value()) {
+      accessibilityValueObject["text"] = accessibilityValue.text.value();
+    }
+    result["accessibilityValue"] = accessibilityValueObject;
+  }
+
+  if (accessibilityActions != oldProps->accessibilityActions) {
+    auto accessibilityActionsArray = folly::dynamic::array();
+    for (const auto& accessibilityAction : accessibilityActions) {
+      folly::dynamic accessibilityActionObject = folly::dynamic::object();
+      accessibilityActionObject["name"] = accessibilityAction.name;
+      if (accessibilityAction.label.has_value()) {
+        accessibilityActionObject["label"] = accessibilityAction.label.value();
+      }
+      accessibilityActionsArray.push_back(accessibilityActionObject);
+    }
+    result["accessibilityActions"] = accessibilityActionsArray;
+  }
+
+  if (accessibilityViewIsModal != oldProps->accessibilityViewIsModal) {
+    result["accessibilityViewIsModal"] = accessibilityViewIsModal;
+  }
+
+  if (accessibilityElementsHidden != oldProps->accessibilityElementsHidden) {
+    result["accessibilityElementsHidden"] = accessibilityElementsHidden;
+  }
+
+  if (accessibilityIgnoresInvertColors !=
+      oldProps->accessibilityIgnoresInvertColors) {
+    result["accessibilityIgnoresInvertColors"] =
+        accessibilityIgnoresInvertColors;
+  }
+
+  if (onAccessibilityTap != oldProps->onAccessibilityTap) {
+    result["onAccessibilityTap"] = onAccessibilityTap;
+  }
+
+  if (onAccessibilityMagicTap != oldProps->onAccessibilityMagicTap) {
+    result["onAccessibilityMagicTap"] = onAccessibilityMagicTap;
+  }
+
+  if (onAccessibilityEscape != oldProps->onAccessibilityEscape) {
+    result["onAccessibilityEscape"] = onAccessibilityEscape;
+  }
+
+  if (onAccessibilityAction != oldProps->onAccessibilityAction) {
+    result["onAccessibilityAction"] = onAccessibilityAction;
+  }
+
+  if (importantForAccessibility != oldProps->importantForAccessibility) {
+    switch (importantForAccessibility) {
+      case ImportantForAccessibility::Auto:
+        result["importantForAccessibility"] = "auto";
+        break;
+      case ImportantForAccessibility::Yes:
+        result["importantForAccessibility"] = "yes";
+        break;
+      case ImportantForAccessibility::No:
+        result["importantForAccessibility"] = "no";
+        break;
+      case ImportantForAccessibility::NoHideDescendants:
+        result["importantForAccessibility"] = "noHideDescendants";
+        break;
+    }
   }
 
   return result;

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -247,7 +247,7 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     enablePropsUpdateReconciliationAndroid: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2024-07-12',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<63601ec83ade8f3774d185ebacf4c792>>
+ * @generated SignedSource<<7adbf7056191e6b287729fc4befbdcbf>>
  * @flow strict
  */
 
@@ -275,7 +275,7 @@ export const enablePreciseSchedulingForPremountItemsOnAndroid: Getter<boolean> =
 /**
  * When enabled, Android will receive prop updates based on the differences between the last rendered shadow node and the last committed shadow node.
  */
-export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNativeFlagGetter('enablePropsUpdateReconciliationAndroid', false);
+export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNativeFlagGetter('enablePropsUpdateReconciliationAndroid', true);
 /**
  * Report paint time inside the Event Timing API implementation (PerformanceObserver).
  */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The PR for branch 0.78.0 is https://github.com/discord/react-native/pull/69.

The feature flag is supported in react-native 0.79 and requires cherrypicking the following commits from [David Vacca](https://github.com/mdvacca?tab=overview&from=2024-11-01&to=2024-11-30): 
- Implement prop diffing for accessibility props in View [#48833](https://github.com/facebook/react-native/pull/48833)
- Implement prop diffing for transform props in View [#48832](https://github.com/facebook/react-native/pull/48832)
- Implement prop diffing for border props in View [#48831](https://github.com/facebook/react-native/pull/48831)
- Implement prop diffing for event props in View [#48830](https://github.com/facebook/react-native/pull/48830)
- Implement prop diffing for basic props in View [#48829](https://github.com/facebook/react-native/pull/48829)

Enables feature flag enablePropsUpdateReconciliationAndroid to fix https://app.asana.com/1/236888843494340/project/1199705967702853/task/1209601835367711?focus=true

More info at https://github.com/facebook/react-native/pull/45551 and https://github.com/discord/react-native/blob/e0702345591cb461e196aabd8be0bf51839a2df3/packages/react-native/scripts/featureflags/README.md

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

This diffs toggles the new Android prop diffing mechanism for components

## Test Plan:

Regressions from previous PR https://github.com/discord/react-native/pull/61 are fixed by cherry picking the above commits. 

Branch 0.78:

| Before enabling the feature flag    | After enabling the feature flag |
| ----------- | ----------- |
| <img src="https://github.com/user-attachments/assets/10a03e97-1e6d-47fd-8492-c02ca3fd0044" width="350" />      | <img src="https://github.com/user-attachments/assets/3bc480b3-3f0b-45a3-aec0-9af1220d0fa5" width="350" />       |

After cherry-picking commits:

<image src="https://github.com/user-attachments/assets/933b8374-c550-45b7-af33-ab6ba9a041c1" width="250" />

Discord:

| Before cherry-pick   | After cherry-pick |
| ----------- | ----------- |
| <video src="https://github.com/user-attachments/assets/b9362bbd-da7f-437d-ad3f-f1ce9d03cc05" width="350" />      | <video src="https://github.com/user-attachments/assets/fc5e0658-6ecc-463f-abc6-c1d3c760fd0f" width="350" />       |
