### PR TITLE
Fix ScrollView with `pagingEnabled` when using ThumbStick

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -718,6 +718,38 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       return false;
     }
 
+    // Handle ACTION_SCROLL events (mouse wheel, trackpad, joystick)
+    if (ev.getActionMasked() == MotionEvent.ACTION_SCROLL) {
+      float hScroll = ev.getAxisValue(MotionEvent.AXIS_HSCROLL);
+      if (hScroll != 0) {
+        // Perform the scroll
+        boolean result = super.dispatchGenericMotionEvent(ev);
+        // Schedule snap alignment to run after scrolling stops
+        if (result
+            && (mPagingEnabled
+                || mSnapInterval != 0
+                || mSnapOffsets != null
+                || mSnapToAlignment != SNAP_ALIGNMENT_DISABLED)) {
+          // Cancel any pending runnable and reschedule
+          if (mPostTouchRunnable != null) {
+            removeCallbacks(mPostTouchRunnable);
+          }
+          mPostTouchRunnable =
+              new Runnable() {
+                @Override
+                public void run() {
+                  mPostTouchRunnable = null;
+                  // Trigger snap alignment now that scrolling has stopped
+                  handlePostTouchScrolling(0, 0);
+                }
+              };
+          ViewCompat.postOnAnimationDelayed(
+              this, mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+        }
+        return result;
+      }
+    }
+
     return super.dispatchGenericMotionEvent(ev);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -557,6 +557,38 @@ public class ReactScrollView extends ScrollView
       return false;
     }
 
+    // Handle ACTION_SCROLL events (mouse wheel, trackpad, joystick)
+    if (ev.getActionMasked() == MotionEvent.ACTION_SCROLL) {
+      float vScroll = ev.getAxisValue(MotionEvent.AXIS_VSCROLL);
+      if (vScroll != 0) {
+        // Perform the scroll
+        boolean result = super.dispatchGenericMotionEvent(ev);
+        // Schedule snap alignment to run after scrolling stops
+        if (result
+            && (mPagingEnabled
+                || mSnapInterval != 0
+                || mSnapOffsets != null
+                || mSnapToAlignment != SNAP_ALIGNMENT_DISABLED)) {
+          // Cancel any pending post-touch runnable and reschedule
+          if (mPostTouchRunnable != null) {
+            removeCallbacks(mPostTouchRunnable);
+          }
+          mPostTouchRunnable =
+              new Runnable() {
+                @Override
+                public void run() {
+                  mPostTouchRunnable = null;
+                  // Trigger snap alignment now that scrolling has stopped
+                  handlePostTouchScrolling(0, 0);
+                }
+              };
+          ViewCompat.postOnAnimationDelayed(
+              this, mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+        }
+        return result;
+      }
+    }
+
     return super.dispatchGenericMotionEvent(ev);
   }
 


### PR DESCRIPTION
This PR fixes the issue where `pagingEnabled` prop wasn't supported for ThumbSticks in the ScrollViews.

This applies the fix from the upstream: https://github.com/facebook/react-native/pull/54226

## Test Plan

Tested it in the `discord` app by building from sources using local `react-native` checkout.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211867289419495