### PR TITLE
Claude fix for stroke positioning in iOS.

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -405,28 +405,13 @@
   [attributedText enumerateAttribute:NSFontAttributeName
                              inRange:NSMakeRange(0, attributedText.length)
                              options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                        usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
-                          if (maximumDescender > font.descender) {
-                            maximumDescender = font.descender;
-                          }
-                        }];
+                          usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
+                            if (maximumDescender > font.descender) {
+                              maximumDescender = font.descender;
+                            }
+                          }];
 
-  // Account for stroke width in baseline calculation
-  __block CGFloat strokeWidth = 0;
-  [attributedText enumerateAttribute:@"RCTTextStrokeWidth"
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:0
-                          usingBlock:^(id value, NSRange range, BOOL *stop) {
-    if (value && [value isKindOfClass:[NSNumber class]]) {
-      CGFloat width = [value floatValue];
-      if (width > 0) {
-        strokeWidth = MAX(strokeWidth, width);
-        *stop = YES;
-      }
-    }
-  }];
-
-  return size.height + maximumDescender + strokeWidth;
+  return size.height + maximumDescender;
 }
 
 static YGSize RCTTextShadowViewMeasure(
@@ -463,29 +448,27 @@ static YGSize RCTTextShadowViewMeasure(
                           inRange:NSMakeRange(0, textStorage.length)
                           options:0
                        usingBlock:^(id value, NSRange range, BOOL *stop) {
-    if (value && [value isKindOfClass:[NSNumber class]]) {
-      CGFloat width = [value floatValue];
-      if (width > 0) {
-        strokeWidth = MAX(strokeWidth, width);
-        *stop = YES;
-      }
-    }
-  }];
+                         if (value && [value isKindOfClass:[NSNumber class]]) {
+                           CGFloat width = [value floatValue];
+                           if (width > 0) {
+                             strokeWidth = MAX(strokeWidth, width);
+                             *stop = YES;
+                           }
+                         }
+                       }];
 
   if (strokeWidth > 0) {
     size.width += strokeWidth;
-    size.height += strokeWidth;
   }
 
-  size = (CGSize){
-      MIN(RCTCeilPixelValue(size.width), maximumSize.width), MIN(RCTCeilPixelValue(size.height), maximumSize.height)};
+  size = (CGSize){MIN(RCTCeilPixelValue(size.width), maximumSize.width),
+                  MIN(RCTCeilPixelValue(size.height), maximumSize.height)};
 
   // Adding epsilon value illuminates problems with converting values from
   // `double` to `float`, and then rounding them to pixel grid in Yoga.
   CGFloat epsilon = 0.001;
-  return (YGSize){
-      RCTYogaFloatFromCoreGraphicsFloat(size.width + epsilon),
-      RCTYogaFloatFromCoreGraphicsFloat(size.height + epsilon)};
+  return (YGSize){RCTYogaFloatFromCoreGraphicsFloat(size.width + epsilon),
+                  RCTYogaFloatFromCoreGraphicsFloat(size.height + epsilon)};
 }
 
 static float RCTTextShadowViewBaseline(YGNodeConstRef node, const float width, const float height)

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -131,21 +131,23 @@
                            inRange:characterRange
                            options:0
                         usingBlock:^(id value, NSRange range, BOOL *stop) {
-    if (value && [value isKindOfClass:[NSNumber class]]) {
-      CGFloat width = [value floatValue];
-      if (width > 0) {
-        hasStroke = YES;
-        strokeWidth = width;
-        strokeColor = [_textStorage attribute:@"RCTTextStrokeColor" atIndex:range.location effectiveRange:NULL];
+                          if (value && [value isKindOfClass:[NSNumber class]]) {
+                            CGFloat width = [value floatValue];
+                            if (width > 0) {
+                              hasStroke = YES;
+                              strokeWidth = width;
+                              strokeColor = [_textStorage attribute:@"RCTTextStrokeColor"
+                                                            atIndex:range.location
+                                                     effectiveRange:NULL];
 
-        if (strokeColor) {
-          CGFloat r, g, b, a;
-          [strokeColor getRed:&r green:&g blue:&b alpha:&a];
-        }
-        *stop = YES;
-      }
-    }
-  }];
+                              if (strokeColor) {
+                                CGFloat r, g, b, a;
+                                [strokeColor getRed:&r green:&g blue:&b alpha:&a];
+                              }
+                              *stop = YES;
+                            }
+                          }
+                        }];
 
   if (hasStroke && strokeColor) {
     CGContextRef context = UIGraphicsGetCurrentContext();
@@ -157,16 +159,17 @@
     CGFloat strokeInset = strokeWidth / 2;
 
     // PASS 1: Draw stroke outline
+    // Note: Only offset X by strokeInset, not Y, to match Android behavior
+    // This ensures consistent vertical spacing when stroke is applied
     CGContextSaveGState(context);
     CGContextSetTextDrawingMode(context, kCGTextStroke);
 
     NSMutableAttributedString *strokeText = [_textStorage mutableCopy];
-    [strokeText addAttribute:NSForegroundColorAttributeName
-                       value:strokeColor
-                       range:characterRange];
+    [strokeText addAttribute:NSForegroundColorAttributeName value:strokeColor range:characterRange];
 
     CGContextSetTextMatrix(context, CGAffineTransformIdentity);
-    CGContextTranslateCTM(context, _contentFrame.origin.x + strokeInset, self.bounds.size.height - _contentFrame.origin.y + strokeInset);
+    CGContextTranslateCTM(
+        context, _contentFrame.origin.x + strokeInset, self.bounds.size.height - _contentFrame.origin.y);
     CGContextScaleCTM(context, 1.0, -1.0);
 
     CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)strokeText);
@@ -184,7 +187,8 @@
     CGContextSetTextDrawingMode(context, kCGTextFill);
 
     CGContextSetTextMatrix(context, CGAffineTransformIdentity);
-    CGContextTranslateCTM(context, _contentFrame.origin.x + strokeInset, self.bounds.size.height - _contentFrame.origin.y + strokeInset);
+    CGContextTranslateCTM(
+        context, _contentFrame.origin.x + strokeInset, self.bounds.size.height - _contentFrame.origin.y);
     CGContextScaleCTM(context, 1.0, -1.0);
 
     framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)_textStorage);


### PR DESCRIPTION
## Summary:

This code is used for rendering display name styles on iOS, whereas Android is rendered with `StrokeStyleSpan` ([see last PR](https://github.com/discord/react-native/pull/122)). Android is currently working correctly, where the stroke does not affect the space occupied by the text in the UI, whereas on iOS there's a visible shift when a stroke is introduced. With this fix, the text height is no longer impacted by the stroke, which is most visible when editing display name styles.

## Changelog:

- Updates the calculation for text baseline when a stroke is present in iOS, so the vertical space occupied in the UI is now consistent with text without a stroke.

## Test Plan:

Followed the [instructions](https://www.notion.so/discordapp/Updating-our-React-Native-fork-b747eeb426bc4748bcd633471736f028) for testing React Native changes locally, and confirmed that the fix is present and working as intended for display name styles.