### PR TITLE
fix: disable recycling in scrollview

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -122,6 +122,10 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   return (RCTScrollViewComponentView *)view;
 }
 
++ (BOOL)shouldBeRecycled {
+    return NO;
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

PR disabling view recycling in RCTScrollView on iOS new arch. It should be considered as a temporary workaround since it is disabling a micro optimization. Should not affect performance compared to old arch, can slightly decrease the RAM usage since these ScrollViews are not kept in memory when not used. https://app.asana.com/1/236888843494340/project/1199705967702853/task/1212395031968848

TODO: investigate why react-native-reanimated does not work correctly with recycling in this case: https://app.asana.com/1/236888843494340/project/1199705967702853/task/1212977499379040