### PR TITLE
Fix: [iOS] Correctly mark inline attachments as clipped when in truncated text range

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -390,6 +390,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
       ceil(size.width * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor,
       ceil(size.height * layoutContext.pointScaleFactor) / layoutContext.pointScaleFactor};
 
+  NSRange visibleGlyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
+
   __block auto attachments = TextMeasurement::Attachments{};
 
   [textStorage
@@ -405,7 +407,14 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                                                      actualCharacterRange:NULL];
                 NSRange truncatedRange =
                     [layoutManager truncatedGlyphRangeInLineFragmentForGlyphAtIndex:attachmentGlyphRange.location];
-                if (truncatedRange.location != NSNotFound && attachmentGlyphRange.location >= truncatedRange.location) {
+
+                // Attachment on a line that did not fit (e.g. on the 4th line when the container is limited to 3 lines)
+                BOOL isOutsideVisibleRange = !NSLocationInRange(attachmentGlyphRange.location, visibleGlyphRange);
+                // Attachment in the ellipsis range of the last visible line (line truncated with "..." and the attachment falls in that portion)
+                BOOL isInTruncatedRange = truncatedRange.location != NSNotFound &&
+                    attachmentGlyphRange.location >= truncatedRange.location;
+
+                if (isOutsideVisibleRange || isInTruncatedRange) {
                   attachments.push_back(TextMeasurement::Attachment{.isClipped = true});
                 } else {
                   CGSize attachmentSize = attachment.bounds.size;


### PR DESCRIPTION
## Summary:

Fixes inline attachments in `<Text>` on iOS (Fabric) so they’re clipped when they’re beyond the `numberOfLines` limit instead of still being rendered.

During work on [Asana ticket](https://app.asana.com/1/236888843494340/project/1213140045202368/task/1209612272448625), we determined the root cause lies in React Native. I’ve proposed a fix in this PR [to facebook/react-native](https://github.com/facebook/react-native/pull/55518); more details are there.





## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
