### PR TITLE
feat(react-image): add a hook to customize ImageRequestBuilder in ReactImageView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageRequestBuilderHook.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageRequestBuilderHook.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.image
+
+import android.net.Uri
+import com.facebook.imagepipeline.request.ImageRequestBuilder
+
+/**
+ * Global hook for mutating [ImageRequestBuilder] instances created by [ReactImageView].
+ *
+ * This is a no-op unless a hook is registered via [setHook].
+ */
+public object ReactImageRequestBuilderHook {
+  public fun interface Hook {
+    public fun apply(sourceUri: Uri, imageRequestBuilder: ImageRequestBuilder)
+  }
+
+  @Volatile private var hook: Hook? = null
+
+  @JvmStatic
+  public fun setHook(newHook: Hook?) {
+    hook = newHook
+  }
+
+  @JvmStatic
+  public fun clearHook() {
+    hook = null
+  }
+
+  internal fun apply(sourceUri: Uri, imageRequestBuilder: ImageRequestBuilder) {
+    hook?.apply(sourceUri, imageRequestBuilder)
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -482,6 +482,7 @@ public class ReactImageView(
     } else {
       imageRequestBuilder.setCacheChoice(ImageRequest.CacheChoice.DEFAULT);
     }
+    ReactImageRequestBuilderHook.apply(uri, imageRequestBuilder)
 
     val imageRequest: ImageRequest =
         ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers, cacheControl)
@@ -518,6 +519,7 @@ public class ReactImageView(
       } else {
         cachedImageRequestBuilder.setCacheChoice(ImageRequest.CacheChoice.DEFAULT);
       }
+      ReactImageRequestBuilderHook.apply(cachedSource.uri, cachedImageRequestBuilder)
 
       val cachedImageRequest = cachedImageRequestBuilder.build()
       builder.setLowResImageRequest(cachedImageRequest)


### PR DESCRIPTION


There was no extension point to tweak JS Image request builders before they get built. ReactImageView only applied its built-in cache choice logic, so app-level request policy could not be injected.

Add a new ReactImageRequestBuilderHook object with setHook and clearHook. Call the hook for both the main image request builder and the low-res cached builder right before build().

- Needed for: https://app.asana.com/1/236888843494340/task/1213290424809812