### PR TITLE
Revert PR #96 GC startup changes

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -131,12 +131,10 @@ std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
 
   auto gcConfig = ::hermes::vm::GCConfig::Builder()
                       // Default to 3GB
-                      .withInitHeapSize(150ll * 1024 * 1024)
-                      .withShouldReleaseUnused(::hermes::vm::kReleaseUnusedNone)
                       .withMaxHeapSize(3072 << 20)
                       .withName("RNBridgeless");
 
-  if (true || allocInOldGenBeforeTTI) {
+  if (allocInOldGenBeforeTTI) {
     // For the next two arguments: avoid GC before TTI
     // by initializing the runtime to allocate directly
     // in the old generation, but revert to normal


### PR DESCRIPTION
This reverts the "Avoid GC during the app start" change (originally from #96) on 0.81.4-discord by reverting commit 491af549a15aaf295af3eca4da6b69d6eecf8edc.