### PR TITLE
Add Hermes occupancy target experiment plumbing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
@@ -12,15 +12,22 @@ import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.soloader.SoLoader
 
-public class HermesInstance(allocInOldGenBeforeTTI: Boolean) :
-    JSRuntimeFactory(initHybrid(allocInOldGenBeforeTTI)) {
+public class HermesInstance(
+    allocInOldGenBeforeTTI: Boolean,
+    useOccupancyTargetExperiment: Boolean,
+) : JSRuntimeFactory(initHybrid(allocInOldGenBeforeTTI, useOccupancyTargetExperiment)) {
 
-  public constructor() : this(false)
+  public constructor(allocInOldGenBeforeTTI: Boolean) : this(allocInOldGenBeforeTTI, false)
+
+  public constructor() : this(false, false)
 
   public companion object {
     @JvmStatic
     @DoNotStrip
-    protected external fun initHybrid(allocInOldGenBeforeTTI: Boolean): HybridData
+    protected external fun initHybrid(
+        allocInOldGenBeforeTTI: Boolean,
+        useOccupancyTargetExperiment: Boolean,
+    ): HybridData
 
     init {
       SoLoader.loadLibrary("hermesinstancejni")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
@@ -13,8 +13,9 @@ namespace facebook::react {
 
 jni::local_ref<JHermesInstance::jhybriddata> JHermesInstance::initHybrid(
     jni::alias_ref<jclass> /* unused */,
-    bool allocInOldGenBeforeTTI) {
-  return makeCxxInstance(allocInOldGenBeforeTTI);
+    bool allocInOldGenBeforeTTI,
+    bool useOccupancyTargetExperiment) {
+  return makeCxxInstance(allocInOldGenBeforeTTI, useOccupancyTargetExperiment);
 }
 
 void JHermesInstance::registerNatives() {
@@ -26,7 +27,10 @@ void JHermesInstance::registerNatives() {
 std::unique_ptr<JSRuntime> JHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
   return HermesInstance::createJSRuntime(
-      nullptr, msgQueueThread, allocInOldGenBeforeTTI_);
+      nullptr,
+      msgQueueThread,
+      allocInOldGenBeforeTTI_,
+      useOccupancyTargetExperiment_);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -27,12 +27,14 @@ class JHermesInstance
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass> /* unused */,
-      bool allocInOldGenBeforeTTI);
+      bool allocInOldGenBeforeTTI,
+      bool useOccupancyTargetExperiment);
 
   static void registerNatives();
 
-  JHermesInstance(bool allocInOldGenBeforeTTI)
-      : allocInOldGenBeforeTTI_(allocInOldGenBeforeTTI){};
+  JHermesInstance(bool allocInOldGenBeforeTTI, bool useOccupancyTargetExperiment)
+      : allocInOldGenBeforeTTI_(allocInOldGenBeforeTTI),
+        useOccupancyTargetExperiment_(useOccupancyTargetExperiment){};
 
   std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
@@ -43,6 +45,7 @@ class JHermesInstance
   friend HybridBase;
 
   bool allocInOldGenBeforeTTI_;
+  bool useOccupancyTargetExperiment_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -126,12 +126,15 @@ class HermesJSRuntime : public JSRuntime {
 std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
     std::shared_ptr<::hermes::vm::CrashManager> crashManager,
     std::shared_ptr<MessageQueueThread> msgQueueThread,
-    bool allocInOldGenBeforeTTI) noexcept {
+    bool allocInOldGenBeforeTTI,
+    bool useOccupancyTargetExperiment) noexcept {
   assert(msgQueueThread != nullptr);
 
   auto gcConfig = ::hermes::vm::GCConfig::Builder()
                       // Default to 3GB
                       .withMaxHeapSize(3072 << 20)
+                      .withOccupancyTarget(
+                          useOccupancyTargetExperiment ? 0.75 : 0.5)
                       .withName("RNBridgeless");
 
   if (allocInOldGenBeforeTTI) {

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
@@ -19,7 +19,8 @@ class HermesInstance {
   static std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<::hermes::vm::CrashManager> crashManager,
       std::shared_ptr<MessageQueueThread> msgQueueThread,
-      bool allocInOldGenBeforeTTI) noexcept;
+      bool allocInOldGenBeforeTTI,
+      bool useOccupancyTargetExperiment = false) noexcept;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
# Add OccupancyTarget experiment to hermes on Android

We want to test `OccupancyTarget=0.75` without hardcoding runtime behavior for everyone.

This change wires the experiment into startup flags so the treatment is available before Hermes is initialized.
Control == default behavior
treatment == higher occupancy target


-ticket: https://app.asana.com/1/236888843494340/project/1213432994847929/task/1213492298100306?focus=true
