### PR TITLE
Fixing the Android rendering path of text strokes, so that the stroke will support multi-line display name styles.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.kt
@@ -33,6 +33,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.facebook.react.views.text.FontMetricsUtil.getFontMetrics
 import com.facebook.react.views.text.internal.span.ReactAbsoluteSizeSpan
+import com.facebook.react.views.text.internal.span.StrokeStyleSpan
 import com.facebook.react.views.text.internal.span.TextInlineViewPlaceholderSpan
 import com.facebook.yoga.YogaBaselineFunction
 import com.facebook.yoga.YogaConstants
@@ -144,6 +145,25 @@ public constructor(reactTextViewManagerCallback: ReactTextViewManagerCallback? =
         layoutHeight = height
       }
     }
+
+    // Reserve room for the text stroke halo so it isn't clipped on multi-line text. Matches the
+    // Fabric path (TextLayoutManager.applyStrokePadding) and iOS (RCTTextShadowView.mm).
+    val strokeWidth = StrokeStyleSpan.getMaxStrokeWidth(text)
+    if (strokeWidth > 0f) {
+      if (widthMode != YogaMeasureMode.EXACTLY) {
+        layoutWidth += strokeWidth
+        if (widthMode == YogaMeasureMode.AT_MOST && layoutWidth > width) {
+          layoutWidth = width
+        }
+      }
+      if (heightMode != YogaMeasureMode.EXACTLY) {
+        layoutHeight += strokeWidth
+        if (heightMode == YogaMeasureMode.AT_MOST && layoutHeight > height) {
+          layoutHeight = height
+        }
+      }
+    }
+
     YogaMeasureOutput.make(layoutWidth, layoutHeight)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * test
  */
 
 package com.facebook.react.views.text;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -991,8 +991,14 @@ internal object TextLayoutManager {
       }
     }
 
-    val widthInSP = calculatedWidth.pxToDp()
-    val heightInSP = calculatedHeight.pxToDp()
+    // Reserve room for the text stroke halo so it isn't clipped, matching iOS behavior in
+    // RCTTextShadowView.mm. Respects EXACTLY/AT_MOST constraints so parents that asked for a
+    // specific size still get one.
+    val paddedWidth = applyStrokePadding(calculatedWidth, text, width, widthYogaMeasureMode)
+    val paddedHeight = applyStrokePadding(calculatedHeight, text, height, heightYogaMeasureMode)
+
+    val widthInSP = paddedWidth.pxToDp()
+    val heightInSP = paddedHeight.pxToDp()
 
     return YogaMeasureOutput.make(widthInSP, heightInSP)
   }
@@ -1015,9 +1021,14 @@ internal object TextLayoutManager {
     val calculatedHeight =
         calculateHeight(layout, height, heightYogaMeasureMode, calculatedLineCount)
 
+    // Reserve room for the text stroke halo so it isn't clipped, matching iOS behavior in
+    // RCTTextShadowView.mm. Respects EXACTLY/AT_MOST constraints.
+    val paddedWidth = applyStrokePadding(calculatedWidth, text, width, widthYogaMeasureMode)
+    val paddedHeight = applyStrokePadding(calculatedHeight, text, height, heightYogaMeasureMode)
+
     val retList = ArrayList<Float>()
-    retList.add(calculatedWidth.pxToDp())
-    retList.add(calculatedHeight.pxToDp())
+    retList.add(paddedWidth.pxToDp())
+    retList.add(paddedHeight.pxToDp())
 
     val metrics = AttachmentMetrics()
     var lastAttachmentFoundInSpan: Int
@@ -1123,6 +1134,25 @@ internal object TextLayoutManager {
       }
     }
     return calculatedHeight
+  }
+
+  /**
+   * Adds stroke width padding to a measured dimension so the stroke halo isn't clipped. Mirrors
+   * iOS behavior in [RCTTextShadowView.mm] where `size.width`/`size.height` are expanded by the
+   * stroke width before clamping to the container's max size. Returns [dimension] unchanged when
+   * no [StrokeStyleSpan] is present or when Yoga requested an EXACTLY-sized box.
+   */
+  private fun applyStrokePadding(
+      dimension: Float,
+      text: Spanned,
+      constraint: Float,
+      measureMode: YogaMeasureMode
+  ): Float {
+    if (measureMode == YogaMeasureMode.EXACTLY) return dimension
+    val strokeWidth = StrokeStyleSpan.getMaxStrokeWidth(text)
+    if (strokeWidth <= 0f) return dimension
+    val padded = dimension + strokeWidth
+    return if (measureMode == YogaMeasureMode.AT_MOST) min(padded, constraint) else padded
   }
 
   private fun nextAttachmentMetrics(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/StrokeStyleSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/StrokeStyleSpan.kt
@@ -72,5 +72,23 @@ public class StrokeStyleSpan(
       val spans = spanned.getSpans(0, spanned.length, StrokeStyleSpan::class.java)
       return spans.firstOrNull()
     }
+
+    /**
+     * Returns the maximum stroke width across all [StrokeStyleSpan]s in [spanned], or 0 if none are
+     * present. Used by the measurement pipeline to reserve room for the stroke halo so it isn't
+     * clipped on multi-line text (matches iOS behavior in RCTTextShadowView.mm).
+     */
+    @JvmStatic
+    public fun getMaxStrokeWidth(spanned: Spanned?): Float {
+      if (spanned == null) return 0f
+      val spans = spanned.getSpans(0, spanned.length, StrokeStyleSpan::class.java)
+      var maxWidth = 0f
+      for (span in spans) {
+        if (span.width > maxWidth) {
+          maxWidth = span.width
+        }
+      }
+      return maxWidth
+    }
   }
 }


### PR DESCRIPTION
tbh these changes are vibe coded, but I've had Claude re-review it a couple times to make tweaks, and confirmed that there's no risk of impacting non-stroked text.

Before:
<img width="392" height="174" alt="image" src="https://github.com/user-attachments/assets/9d53c3ea-71f2-45e5-8bfc-3c4760ffce83" />

After: