### PR TITLE
Add useTraitHiddenOnIOS feature flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<94a1d6bbc5595c495a2c54851a9c5b5b>>
+ * @generated SignedSource<<a03d363d13ff18dd87d15dc223c9c32d>>
  */
 
 /**
@@ -395,6 +395,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useSilenceErrorSMMViewNotFound(): Boolean = accessor.useSilenceErrorSMMViewNotFound()
+
+  /**
+   * iOS only. When true (default), shadow nodes carrying ShadowNodeTraits::Trait::Hidden are filtered out of the mounting slice. When false, those nodes stay in the slice and are hidden via UIView.hidden = YES in updateLayoutMetrics:.
+   */
+  @JvmStatic
+  public fun useTraitHiddenOnIOS(): Boolean = accessor.useTraitHiddenOnIOS()
 
   /**
    * In Bridgeless mode, should legacy NativeModules use the TurboModule system?

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4e19cdce9383c287c849b912fa74586c>>
+ * @generated SignedSource<<b3ddcd5c53e3fec3c0397dbeaa2a3b0c>>
  */
 
 /**
@@ -81,6 +81,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var useRawPropsJsiValueCache: Boolean? = null
   private var useShadowNodeStateOnCloneCache: Boolean? = null
   private var useSilenceErrorSMMViewNotFoundCache: Boolean? = null
+  private var useTraitHiddenOnIOSCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
   private var virtualViewPrerenderRatioCache: Double? = null
@@ -631,6 +632,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useSilenceErrorSMMViewNotFound()
       useSilenceErrorSMMViewNotFoundCache = cached
+    }
+    return cached
+  }
+
+  override fun useTraitHiddenOnIOS(): Boolean {
+    var cached = useTraitHiddenOnIOSCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useTraitHiddenOnIOS()
+      useTraitHiddenOnIOSCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2a525ef08b04eb1c244badb8cc865e4d>>
+ * @generated SignedSource<<1234d5c7c6bb64451618817387318d13>>
  */
 
 /**
@@ -149,6 +149,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useShadowNodeStateOnClone(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useSilenceErrorSMMViewNotFound(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useTraitHiddenOnIOS(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useTurboModuleInterop(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<58b3101bd16b63268440523cdee7ae93>>
+ * @generated SignedSource<<3255db6cb7c71d866991568dc632321f>>
  */
 
 /**
@@ -144,6 +144,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useShadowNodeStateOnClone(): Boolean = false
 
   override fun useSilenceErrorSMMViewNotFound(): Boolean = false
+
+  override fun useTraitHiddenOnIOS(): Boolean = true
 
   override fun useTurboModuleInterop(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3c639d5edf52fc3feee65388b5ac3ed7>>
+ * @generated SignedSource<<6f23f8fd399adf79814bb8f2edc29841>>
  */
 
 /**
@@ -85,6 +85,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var useRawPropsJsiValueCache: Boolean? = null
   private var useShadowNodeStateOnCloneCache: Boolean? = null
   private var useSilenceErrorSMMViewNotFoundCache: Boolean? = null
+  private var useTraitHiddenOnIOSCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
   private var virtualViewPrerenderRatioCache: Double? = null
@@ -696,6 +697,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useSilenceErrorSMMViewNotFound()
       accessedFeatureFlags.add("useSilenceErrorSMMViewNotFound")
       useSilenceErrorSMMViewNotFoundCache = cached
+    }
+    return cached
+  }
+
+  override fun useTraitHiddenOnIOS(): Boolean {
+    var cached = useTraitHiddenOnIOSCache
+    if (cached == null) {
+      cached = currentProvider.useTraitHiddenOnIOS()
+      accessedFeatureFlags.add("useTraitHiddenOnIOS")
+      useTraitHiddenOnIOSCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0a4b05562ed8b30b7d4dabd5c8680d6d>>
+ * @generated SignedSource<<2877a4acf03951884d1d663fdf00b9f8>>
  */
 
 /**
@@ -144,6 +144,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useShadowNodeStateOnClone(): Boolean
 
   @DoNotStrip public fun useSilenceErrorSMMViewNotFound(): Boolean
+
+  @DoNotStrip public fun useTraitHiddenOnIOS(): Boolean
 
   @DoNotStrip public fun useTurboModuleInterop(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<64b1d9667e6869ea4ba406222b307464>>
+ * @generated SignedSource<<c3ce57d947ffe2b5b404acd4a8527ae0>>
  */
 
 /**
@@ -405,6 +405,12 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
+  bool useTraitHiddenOnIOS() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useTraitHiddenOnIOS");
+    return method(javaProvider_);
+  }
+
   bool useTurboModuleInterop() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useTurboModuleInterop");
@@ -738,6 +744,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useSilenceErrorSMMViewNotFound(
   return ReactNativeFeatureFlags::useSilenceErrorSMMViewNotFound();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useTraitHiddenOnIOS(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useTraitHiddenOnIOS();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useTurboModuleInterop(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useTurboModuleInterop();
@@ -972,6 +983,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useSilenceErrorSMMViewNotFound",
         JReactNativeFeatureFlagsCxxInterop::useSilenceErrorSMMViewNotFound),
+      makeNativeMethod(
+        "useTraitHiddenOnIOS",
+        JReactNativeFeatureFlagsCxxInterop::useTraitHiddenOnIOS),
       makeNativeMethod(
         "useTurboModuleInterop",
         JReactNativeFeatureFlagsCxxInterop::useTurboModuleInterop),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<073595986845439fdcb30edc52dadc30>>
+ * @generated SignedSource<<f4d8c8c96e3d7075dc71b8ac048fc7e0>>
  */
 
 /**
@@ -211,6 +211,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useSilenceErrorSMMViewNotFound(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useTraitHiddenOnIOS(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useTurboModuleInterop(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<eb8488e034b281dc5cf384aa48b0ecf0>>
+ * @generated SignedSource<<bd604e84ed03731ac48b2c0f41b36089>>
  */
 
 /**
@@ -268,6 +268,10 @@ bool ReactNativeFeatureFlags::useShadowNodeStateOnClone() {
 
 bool ReactNativeFeatureFlags::useSilenceErrorSMMViewNotFound() {
   return getAccessor().useSilenceErrorSMMViewNotFound();
+}
+
+bool ReactNativeFeatureFlags::useTraitHiddenOnIOS() {
+  return getAccessor().useTraitHiddenOnIOS();
 }
 
 bool ReactNativeFeatureFlags::useTurboModuleInterop() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7b1258f9970366f0c068f28e2c16ce12>>
+ * @generated SignedSource<<8dc801da5ad5fd085dcedb245f7dee08>>
  */
 
 /**
@@ -343,6 +343,11 @@ class ReactNativeFeatureFlags {
    * Don't hard crash in SurfaceMountingManager when a view is not found. Instead, log a soft error.
    */
   RN_EXPORT static bool useSilenceErrorSMMViewNotFound();
+
+  /**
+   * iOS only. When true (default), shadow nodes carrying ShadowNodeTraits::Trait::Hidden are filtered out of the mounting slice. When false, those nodes stay in the slice and are hidden via UIView.hidden = YES in updateLayoutMetrics:.
+   */
+  RN_EXPORT static bool useTraitHiddenOnIOS();
 
   /**
    * In Bridgeless mode, should legacy NativeModules use the TurboModule system?

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<85d9a99e79df5428b4b6264cedbc505c>>
+ * @generated SignedSource<<10aa043b91c4189bd7772066085e168d>>
  */
 
 /**
@@ -1127,6 +1127,24 @@ bool ReactNativeFeatureFlagsAccessor::useSilenceErrorSMMViewNotFound() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnIOS() {
+  auto flagValue = useTraitHiddenOnIOS_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(61, "useTraitHiddenOnIOS");
+
+    flagValue = currentProvider_->useTraitHiddenOnIOS();
+    useTraitHiddenOnIOS_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
   auto flagValue = useTurboModuleInterop_.load();
 
@@ -1136,7 +1154,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(61, "useTurboModuleInterop");
+    markFlagAsAccessed(62, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1154,7 +1172,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(62, "useTurboModules");
+    markFlagAsAccessed(63, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1172,7 +1190,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(63, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(64, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;
@@ -1190,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::runtimeCrashUiThreadUtils() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "runtimeCrashUiThreadUtils");
+    markFlagAsAccessed(65, "runtimeCrashUiThreadUtils");
 
     flagValue = currentProvider_->runtimeCrashUiThreadUtils();
     runtimeCrashUiThreadUtils_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8abeb54955dff119219c983bca1024e9>>
+ * @generated SignedSource<<98d2d767bf370439a9efc44a745ae802>>
  */
 
 /**
@@ -93,6 +93,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useRawPropsJsiValue();
   bool useShadowNodeStateOnClone();
   bool useSilenceErrorSMMViewNotFound();
+  bool useTraitHiddenOnIOS();
   bool useTurboModuleInterop();
   bool useTurboModules();
   double virtualViewPrerenderRatio();
@@ -108,7 +109,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 65> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 66> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> animatedShouldSignalBatch_;
@@ -171,6 +172,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useRawPropsJsiValue_;
   std::atomic<std::optional<bool>> useShadowNodeStateOnClone_;
   std::atomic<std::optional<bool>> useSilenceErrorSMMViewNotFound_;
+  std::atomic<std::optional<bool>> useTraitHiddenOnIOS_;
   std::atomic<std::optional<bool>> useTurboModuleInterop_;
   std::atomic<std::optional<bool>> useTurboModules_;
   std::atomic<std::optional<double>> virtualViewPrerenderRatio_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<19c983e30b5131ab5904437f4cc9bbb4>>
+ * @generated SignedSource<<5cb395cf45a846c4e93b4eb5ca2d99e3>>
  */
 
 /**
@@ -269,6 +269,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool useSilenceErrorSMMViewNotFound() override {
     return false;
+  }
+
+  bool useTraitHiddenOnIOS() override {
+    return true;
   }
 
   bool useTurboModuleInterop() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<52f0e78c7c4e53f8adac6cc796a79d7c>>
+ * @generated SignedSource<<627e0e191716b63f3a5dd7fd343506b9>>
  */
 
 /**
@@ -592,6 +592,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useSilenceErrorSMMViewNotFound();
+  }
+
+  bool useTraitHiddenOnIOS() override {
+    auto value = values_["useTraitHiddenOnIOS"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::useTraitHiddenOnIOS();
   }
 
   bool useTurboModuleInterop() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6001012c023fa00b026359cb87fbf2b2>>
+ * @generated SignedSource<<a9c9ed57862c214592fe0d1ffaad8014>>
  */
 
 /**
@@ -86,6 +86,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useRawPropsJsiValue() = 0;
   virtual bool useShadowNodeStateOnClone() = 0;
   virtual bool useSilenceErrorSMMViewNotFound() = 0;
+  virtual bool useTraitHiddenOnIOS() = 0;
   virtual bool useTurboModuleInterop() = 0;
   virtual bool useTurboModules() = 0;
   virtual double virtualViewPrerenderRatio() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0b28e6659211377d63a87f71cf74f4c9>>
+ * @generated SignedSource<<4f37b3bec59e6d9cd6e61e4ecbbe7b6d>>
  */
 
 /**
@@ -347,6 +347,11 @@ bool NativeReactNativeFeatureFlags::useShadowNodeStateOnClone(
 bool NativeReactNativeFeatureFlags::useSilenceErrorSMMViewNotFound(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useSilenceErrorSMMViewNotFound();
+}
+
+bool NativeReactNativeFeatureFlags::useTraitHiddenOnIOS(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useTraitHiddenOnIOS();
 }
 
 bool NativeReactNativeFeatureFlags::useTurboModuleInterop(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5595823614f9ec3f20d95ce21cb7b4d2>>
+ * @generated SignedSource<<267e09d240d84ae5613aa58e2ed1deb8>>
  */
 
 /**
@@ -157,6 +157,8 @@ class NativeReactNativeFeatureFlags
   bool useShadowNodeStateOnClone(jsi::Runtime& runtime);
 
   bool useSilenceErrorSMMViewNotFound(jsi::Runtime& runtime);
+
+  bool useTraitHiddenOnIOS(jsi::Runtime& runtime);
 
   bool useTurboModuleInterop(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
@@ -59,7 +59,11 @@ static void sliceChildShadowNodeViewPairsRecursively(
 #ifndef ANDROID
     // T153547836: Disabled on Android because the mounting infrastructure
     // is not fully ready yet.
-    if (childShadowNode.getTraits().check(ShadowNodeTraits::Trait::Hidden)) {
+    // On iOS, gated by useTraitHiddenOnIOS. When false, the view stays in
+    // the slice and is hidden via UIView.hidden = YES in
+    // updateLayoutMetrics: instead of being removed.
+    if (ReactNativeFeatureFlags::useTraitHiddenOnIOS() &&
+        childShadowNode.getTraits().check(ShadowNodeTraits::Trait::Hidden)) {
       continue;
     }
 #endif

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -692,6 +692,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    useTraitHiddenOnIOS: {
+      defaultValue: true,
+      metadata: {
+        dateAdded: '2026-04-29',
+        description:
+          'iOS only. When true (default), shadow nodes carrying ShadowNodeTraits::Trait::Hidden are filtered out of the mounting slice. When false, those nodes stay in the slice and are hidden via UIView.hidden = YES in updateLayoutMetrics:.',
+        expectedReleaseValue: false,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     useTurboModuleInterop: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<94e87435c32d010d0a3943fd71fc099f>>
+ * @generated SignedSource<<2d214619ebe2d8c61230de56ebfd95f6>>
  * @flow strict
  * @noformat
  */
@@ -112,6 +112,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   useRawPropsJsiValue: Getter<boolean>,
   useShadowNodeStateOnClone: Getter<boolean>,
   useSilenceErrorSMMViewNotFound: Getter<boolean>,
+  useTraitHiddenOnIOS: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
   useTurboModules: Getter<boolean>,
   virtualViewPrerenderRatio: Getter<number>,
@@ -446,6 +447,10 @@ export const useShadowNodeStateOnClone: Getter<boolean> = createNativeFlagGetter
  * Don't hard crash in SurfaceMountingManager when a view is not found. Instead, log a soft error.
  */
 export const useSilenceErrorSMMViewNotFound: Getter<boolean> = createNativeFlagGetter('useSilenceErrorSMMViewNotFound', false);
+/**
+ * iOS only. When true (default), shadow nodes carrying ShadowNodeTraits::Trait::Hidden are filtered out of the mounting slice. When false, those nodes stay in the slice and are hidden via UIView.hidden = YES in updateLayoutMetrics:.
+ */
+export const useTraitHiddenOnIOS: Getter<boolean> = createNativeFlagGetter('useTraitHiddenOnIOS', true);
 /**
  * In Bridgeless mode, should legacy NativeModules use the TurboModule system?
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e1bb52e89fa8e5869afb3304a8e6e6de>>
+ * @generated SignedSource<<c713ac182065b7fce8c04cc1ed75c5af>>
  * @flow strict
  * @noformat
  */
@@ -86,6 +86,7 @@ export interface Spec extends TurboModule {
   +useRawPropsJsiValue?: () => boolean;
   +useShadowNodeStateOnClone?: () => boolean;
   +useSilenceErrorSMMViewNotFound?: () => boolean;
+  +useTraitHiddenOnIOS?: () => boolean;
   +useTurboModuleInterop?: () => boolean;
   +useTurboModules?: () => boolean;
   +virtualViewPrerenderRatio?: () => number;


### PR DESCRIPTION
## Summary:

Adds `useTraitHiddenOnIOS` feature flag - the iOS twin of Meta's
`useTraitHiddenOnAndroid` ([#54112](https://github.com/facebook/react-native/pull/54112)). Defaults to `true` so iOS behavior
is unchanged for anyone who doesn't override it.

Both the [chat empty on channel re entry bug](https://app.asana.com/1/236888843494340/project/1199705967702853/task/1212560151566777?focus=true) and that [chat to non-chat bug](https://app.asana.com/1/236888843494340/project/1214321200370853/task/1214018817192032?focus=true) that we've been chasing come from
iOS Fabric tearing down Suspense-frozen subtrees on every freeze
cycle. `DCDChatComponentView` (and its entire row cache, scroll
position, etc.) gets destroyed and rebuilt every time a chat surface
goes under `display: none`.



RN's been carrying the [wiring to hide views](https://github.com/facebook/react-native/blob/78a740d40aa2f9284b4568cb14307628e0f1d3f1/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm#L117-L119) instead of [destroying](https://github.com/facebook/react-native/blob/78a740d40aa2f9284b4568cb14307628e0f1d3f1/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp#L65-L66)
them since 2018. A 2020 [optimization](https://github.com/facebook/react-native/commit/3c69a9eb4b53c5f1b6f480cf96d88df27bb596f1) started filtering hidden subtrees out of the mounting slice before they could reach that path.

This flag re-opens it on demand.

## Next
- Follow-up app PR (after we bump the RN hash) flips the flag to
`false` in our `RCTAppDelegate` and ships the fix.


## What's in this PR

- 1-line gate in `sliceChildShadowNodeViewPairs.cpp` (the only important code change). 
- Flag declared in `ReactNativeFeatureFlags.config.js`,
  `defaultValue: true` plus ~20 auto-generated files needed for the flag


## Upstream

Designed to go straight to `facebook/react-native` once it's stable
here.


## TODO when we upgrade RN to 0.83

RN 0.83 (which ships `useTraitHiddenOnAndroid` (facebook/react-native#54112), if we upgrade we should drop this
`#ifndef ANDROID` [line ](https://github.com/discord/react-native/pull/172/changes#diff-e648c386e278437ee6997a9fc2a96f28e6fc21e621921f9da4a986dee844a74bR59)and inline both flags into the gate using the following structure:

```c++
if (
  #ifdef ANDROID
      ReactNativeFeatureFlags::useTraitHiddenOnAndroid() &&
  #elif defined(__APPLE__)
      ReactNativeFeatureFlags::useTraitHiddenOnIOS() &&
  #endif
      childShadowNode.getTraits().check(ShadowNodeTraits::Trait::Hidden)) {
    continue;
  }
```
Which is also the code I'll upstream to RN
Behavior is unchanged either way - the rewrite is purely cosmetic